### PR TITLE
Adds `frogtip` command for a random Cool Frog Tip

### DIFF
--- a/plugins/frogtip.js
+++ b/plugins/frogtip.js
@@ -1,0 +1,27 @@
+const _ = require('lodash');
+const request = require('request');
+
+const FROG_API = 'http://frog.tips/api/1/tips';
+
+module.exports = {
+  regex: /frogtip/,
+
+  description: 'frog care and feeding',
+
+  requirePrefix: true,
+
+  fn(data) {
+    return new Promise((resolve, reject) => {
+      request.get({
+        uri: FROG_API,
+        json: true
+      }, (err, response, body) => {
+        if (err) return reject(err);
+
+        const tip = _.sample(body.tips);
+
+        return resolve(`\`${tip}\` :frog:`);
+      });
+    });
+  }
+};


### PR DESCRIPTION
Allows garfbot to respond to `frogtip`. The response is a randomly
selected frog tip hand picked from the http://frog.tips API.

       **REMOVAL OF LABELS WILL VOID FROG'S WARRANTY**