### PR TITLE
Updates deploy script & restores CI deploys

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -26,22 +26,23 @@ cat << "GARF_SENTINEL"
                         `"""`
 GARF_SENTINEL
 
-echo "DEPLOYING GARFWEB TO $GARFWEB_HOST AS $GARFWEB_USER"
+echo "DEPLOYING GARFWEB TO $GARFWEB_HOST:$GARFWEB_PORT AS $GARFWEB_USER"
 
 bin_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
 garfbot_path=$bin_path/..
 
 echo "Copying garf files..."
 rsync -av --delete --progress --stats \
-      --exclude 'node_modules' --exclude 'config/local.json' \
+      --exclude 'node_modules' --exclude 'config/local.js' \
+      -e "ssh -p $GARFWEB_PORT" \
       $garfbot_path $GARFWEB_USER@$GARFWEB_HOST:~/garfbot
 
 echo "Garf copy complete."
 
 echo "Installing garf packages..."
-ssh $GARFWEB_USER@$GARFWEB_HOST -t 'bash -l -c "cd garfbot && npm install"'
+ssh -p $GARFWEB_PORT $GARFWEB_USER@$GARFWEB_HOST -t 'bash -l -c "cd garfbot && npm install"'
 echo "Garf install complete."
 
 echo "Copying garf secrets..."
-ssh $GARFWEB_USER@$GARFWEB_HOST -t 'bash -l -c "cp ~/secrets.json garfbot/config/local.json"'
+ssh -p $GARFWEB_PORT $GARFWEB_USER@$GARFWEB_HOST -t 'bash -l -c "cp ~/secrets.js garfbot/config/local.js"'
 echo "Garf secrets copied."

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
 machine:
   node:
     version: 5.4
+deployment:
+  production:
+    branch: master
+    commands:
+      - ./bin/deploy.sh


### PR DESCRIPTION
Two primary changes:

1. The config files have a `.js` extension these days, not `.json`
2. I added support for a `GARFWEB_PORT` env variable because the current "prod" server runs its SSHD on a non-default port (tinfoil hats r us)
