### PR TITLE
mktheme plugin v0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mongoose": "^4.4.3",
     "mongoose-random": "^0.1.1",
     "nodemon": "^1.8.1",
+    "randomcolor": "^0.4.4",
     "request": "^2.69.0",
     "require-all": "^2.0.0",
     "simple-ngram-markov": "^1.0.4",

--- a/plugins/mktheme.js
+++ b/plugins/mktheme.js
@@ -1,0 +1,41 @@
+const logger = require('../utils/logger');
+const slackAPI = require('../lib/slack-api');
+const randomColour = require('randomcolor');
+const config = require('config');
+
+// There are 8 colours to a Slack theme
+const themeColours = 8;
+
+const regex = /mktheme( [\w]+)?/;
+
+module.exports = {
+  regex,
+
+  description: 'Garf generates a random Slack theme for you',
+
+  requirePrefix: true,
+
+  fn(message) {
+    var opts = {
+      count: themeColours
+    }
+
+    const matches = regex.exec(message.text);
+    if (matches.length >= 2) {
+      const hue = matches[1].trim();
+      opts['hue'] = hue;
+    }
+
+    const colours = randomColour(opts);
+    var theme = ""
+
+    for (var i = 0; i < themeColours; i++) {
+      theme += colours[i];
+      if (i < (themeColours - 1)) {
+        theme += ",";
+      }
+    }
+
+    return Promise.resolve(theme);
+  }
+};

--- a/plugins/mktheme.js
+++ b/plugins/mktheme.js
@@ -31,7 +31,6 @@ module.exports = {
     logger.info(colours);
 
     const theme = values(colours).join(',');
-
     return Promise.resolve(theme);
   }
 };

--- a/plugins/mktheme.js
+++ b/plugins/mktheme.js
@@ -18,21 +18,21 @@ module.exports = {
   fn(message) {
     var opts = {
       count: themeColours
-    }
+    };
+    var theme = '';
 
     const matches = regex.exec(message.text);
     if (matches.length >= 2) {
       const hue = matches[1].trim();
-      opts['hue'] = hue;
+      opts.hue = hue;
     }
 
     const colours = randomColour(opts);
-    var theme = ""
 
     for (var i = 0; i < themeColours; i++) {
       theme += colours[i];
       if (i < (themeColours - 1)) {
-        theme += ",";
+        theme += ',';
       }
     }
 

--- a/plugins/mktheme.js
+++ b/plugins/mktheme.js
@@ -1,10 +1,11 @@
 const logger = require('../utils/logger');
 const slackAPI = require('../lib/slack-api');
 const randomColour = require('randomcolor');
+const values = require('lodash/values');
 const config = require('config');
 
 // There are 8 colours to a Slack theme
-const themeColours = 8;
+const NUM_THEME_COLOURS = 8;
 
 const regex = /mktheme( [\w]+)?/;
 
@@ -17,9 +18,8 @@ module.exports = {
 
   fn(message) {
     var opts = {
-      count: themeColours
+      count: NUM_THEME_COLOURS
     };
-    var theme = '';
 
     const matches = regex.exec(message.text);
     if (matches.length >= 2) {
@@ -28,13 +28,9 @@ module.exports = {
     }
 
     const colours = randomColour(opts);
+    logger.info(colours);
 
-    for (var i = 0; i < themeColours; i++) {
-      theme += colours[i];
-      if (i < (themeColours - 1)) {
-        theme += ',';
-      }
-    }
+    const theme = values(colours).join(',');
 
     return Promise.resolve(theme);
   }


### PR DESCRIPTION
Adds a `mktheme` command that accepts an optional hue. When invoked the plugin will generate 8 random colours using [randomcolor](https://randomcolor.llllll.li/) and send them to the Slack channel.

Unfortunately right now it seems like Slack won't do the HTML colour code previews or the "Switch sidebar theme" functionality for bot messages, so you have to copy/paste the Bot's suggested random theme to be able to switch to it. I opened a Slack help request to see if there's a workaround.

