### PR TITLE
Topic tracker plugin (Part 1)

### DIFF
--- a/models/topic-schema.js
+++ b/models/topic-schema.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const TopicSchema = mongoose.Schema({
+  creator: String,
+  channel: String,
+  topic: String,
+  date: String,
+});
+
+TopicSchema.plugin(require('mongoose-random'));
+TopicSchema.plugin(require('mongoose-find-one-or-create'));
+
+module.exports = mongoose.model('Topic', TopicSchema);

--- a/plugins/topic-watch.js
+++ b/plugins/topic-watch.js
@@ -37,6 +37,7 @@ module.exports = {
       topic,
       date: message.ts,
     });
+
     topicRecord.save().then(result => {
       return Topic.count();
     }).then(count => {

--- a/plugins/topic-watch.js
+++ b/plugins/topic-watch.js
@@ -4,7 +4,7 @@ const config = require('config');
 const Topic = require('../models/topic-schema');
 const names = require('../utils/names');
 
-const regex = /^<@([\w]+)\|[\w]+> set the channel topic: (.*)$/
+const regex = /^<@([\w]+)\|[\w]+> set the channel topic: (.*)$/;
 
 module.exports = {
   regex,
@@ -24,17 +24,17 @@ module.exports = {
       return null;
     }
 
-    const author = matches[1];
-    const authorName = names.idToName(author);
+    const creator = matches[1];
+    const creatorName = names.idToName(creator);
     const topic = matches[2];
     const channel = message.channel;
     const channelName = names.channelToName(channel);
-    logger.info('Caught', channelName, 'topic change by', authorName, 'to', topic);
+    logger.info('Caught', channelName, 'topic change by', creatorName, 'to', topic);
 
     const topicRecord = new Topic({
-      creator: author,
-      channel: channel,
-      topic: topic,
+      creator,
+      channel,
+      topic,
       date: message.ts,
     });
     topicRecord.save().then(result => {

--- a/plugins/topic-watch.js
+++ b/plugins/topic-watch.js
@@ -1,0 +1,52 @@
+const logger = require('../utils/logger');
+const slackAPI = require('../lib/slack-api');
+const config = require('config');
+const Topic = require('../models/topic-schema');
+const names = require('../utils/names');
+
+const regex = /^<@([\w]+)\|[\w]+> set the channel topic: (.*)$/
+
+module.exports = {
+  regex,
+
+  description: 'channel topic tracker',
+
+  requirePrefix: false,
+
+  fn(message) {
+    // Only process channel_topic messages
+    if (message.subtype !== 'channel_topic') {
+      return null;
+    }
+    // Only process messages that match the regex for user/topic
+    const matches = regex.exec(message.text);
+    if (matches.length < 3) {
+      return null;
+    }
+
+    const author = matches[1];
+    const authorName = names.idToName(author);
+    const topic = matches[2];
+    const channel = message.channel;
+    const channelName = names.channelToName(channel);
+    logger.info('Caught', channelName, 'topic change by', authorName, 'to', topic);
+
+    const topicRecord = new Topic({
+      creator: author,
+      channel: channel,
+      topic: topic,
+      date: message.ts,
+    });
+    topicRecord.save().then(result => {
+      return Topic.count();
+    }).then(count => {
+      const replyTo = {
+        channel: message.channel,
+        timestamp: message.ts
+      };
+      logger.info('total topics:', count);
+      slackAPI.reactions.add('mag', replyTo);
+      slackAPI.reactions.add('newspaper', replyTo);
+    });
+  }
+};

--- a/utils/names.js
+++ b/utils/names.js
@@ -9,6 +9,16 @@ const idToName = (userID) => {
   return uInfo ? uInfo.name : 'Unknown';
 };
 
+
+/**
+ * @param {string} channelID - a slack channel ID (e.g. 'C39FWB6SF')
+ * @returns {string} the friendly channel name or 'Unknown'
+ */
+const channelToName = (channelID) => {
+  const cInfo = slackClient.dataStore.getChannelById(channelID);
+  return cInfo ? cInfo.name : 'Unknown';
+};
+
 /**
  * @param {string} username - a friendly username (e.g. 'cpu')
  * @returns {string} a 'quiet' version of the name that won't alert (e.g.
@@ -24,4 +34,5 @@ const quietName = (username) => {
 module.exports = {
   idToName,
   quietName,
+  channelToName,
 };


### PR DESCRIPTION
This commit adds a plugin that watches channels the bot is in for topic
changes. When a topic change occurs the new topic is saved along with
the ID of the user that changed it, the timestamp of the change and the
ID of the slack channel who's topic was changed.

*TODO*: Retrieving the history of topic changes/a random topic

Updates: https://github.com/doeg/garfbot/issues/49
